### PR TITLE
feat(embedderconfig): add embedding_openai_endpoint argument to EmbedderConfig for custom OpenAI deployments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **Migrate Jira Source connector from V1 to V2**
 * **Add Jira Source connector integration and unit tests**
+* **Added option for custom OpenAI baseurl in EmbedderConfig**
 
 ## 0.5.9
 

--- a/unstructured_ingest/embed/openai.py
+++ b/unstructured_ingest/embed/openai.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field, SecretStr
 
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 class OpenAIEmbeddingConfig(EmbeddingConfig):
     api_key: SecretStr
     embedder_model_name: str = Field(default="text-embedding-ada-002", alias="model_name")
+    base_url: Optional[str] = Field(default=None)
 
     def wrap_error(self, e: Exception) -> Exception:
         if is_internal_error(e=e):
@@ -57,13 +58,13 @@ class OpenAIEmbeddingConfig(EmbeddingConfig):
     def get_client(self) -> "OpenAI":
         from openai import OpenAI
 
-        return OpenAI(api_key=self.api_key.get_secret_value())
+        return OpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
     @requires_dependencies(["openai"], extras="openai")
     def get_async_client(self) -> "AsyncOpenAI":
         from openai import AsyncOpenAI
 
-        return AsyncOpenAI(api_key=self.api_key.get_secret_value())
+        return AsyncOpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
 
 
 @dataclass

--- a/unstructured_ingest/v2/processes/embedder.py
+++ b/unstructured_ingest/v2/processes/embedder.py
@@ -52,6 +52,11 @@ class EmbedderConfig(BaseModel):
     embedding_azure_api_version: Optional[str] = Field(
         description="Azure API version", default=None
     )
+    embedding_openai_endpoint: Optional[str] = Field(
+        default=None,
+        description="Your custom OpenAI base url, "
+        "e.g. `https://custom-openai-deployment.com/`",
+    )
 
     def get_huggingface_embedder(self, embedding_kwargs: dict) -> "BaseEmbeddingEncoder":
         from unstructured_ingest.embed.huggingface import (
@@ -66,7 +71,16 @@ class EmbedderConfig(BaseModel):
     def get_openai_embedder(self, embedding_kwargs: dict) -> "BaseEmbeddingEncoder":
         from unstructured_ingest.embed.openai import OpenAIEmbeddingConfig, OpenAIEmbeddingEncoder
 
-        return OpenAIEmbeddingEncoder(config=OpenAIEmbeddingConfig.model_validate(embedding_kwargs))
+        config_kwargs = {
+            "api_key": self.embedding_api_key,
+            "base_url": self.embedding_openai_endpoint,
+        }
+        if model_name := self.embedding_model_name:
+            config_kwargs["model_name"] = model_name
+
+        return OpenAIEmbeddingEncoder(
+            config=OpenAIEmbeddingConfig.model_validate(config_kwargs)
+            )
 
     def get_azure_openai_embedder(self, embedding_kwargs: dict) -> "BaseEmbeddingEncoder":
         from unstructured_ingest.embed.azure_openai import (


### PR DESCRIPTION
### Summary
This pull request adds a `embedding_openai_endpoint` argument to the `EmbedderConfig` class, allowing users to set a custom `base_url` when using an OpenAI client. This is essential for custom LLM deployments that follow the OpenAI API convention.

### Details
- Added `embedding_openai_endpoint` argument to `EmbedderConfig` class.
- Ensured backward compatibility by providing a default value for `base_url`.

### Testing
I have verified that the changes work for our custom deployment. I have also verified that the change does not break Pipeline if no embedding_openai_endpoint is provided. 

```python
from unstructured_ingest.v2.processes.embedder import EmbedderConfig
from unstructured_ingest.embed.openai import OpenAIEmbeddingConfig, OpenAIEmbeddingEncoder

embedder_config=EmbedderConfig(
        embedding_provider='openai',
        embedding_api_key="your_api_key",
        embedding_openai_endpoint='https://custom-openai-instance.com'
        )
# Initialize the OpenAI client with the custom config as done in EmbedderConfig.get_openai_embedder()
config_kwargs = {
            "api_key": embedder_config.embedding_api_key,
            "base_url": embedder_config.embedding_openai_endpoint,
        }
        
if model_name := embedder_config.embedding_model_name:
            config_kwargs["model_name"] = model_name

client = OpenAIEmbeddingEncoder(config=OpenAIEmbeddingConfig.model_validate(config_kwargs))
# Verify that the base URL is correctly set
assert client.config.base_url == "https://custom-openai-instance.com"
